### PR TITLE
Standardize steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,12 +29,12 @@ pipeline {
       parallel {
         stage('Acceptance tests') {
           steps {
-            sh 'echo "Running Behat"'
+            echo 'Running Behat'
           }
         }
         stage('Backend Performance') {
           steps {
-            sh 'echo "Running Blackfire"'
+            echo 'Running Blackfire'
           }
         }
         stage('Frontend Performance') {


### PR DESCRIPTION
Always use `echo` without the `sh` wrapper.